### PR TITLE
State IRONdb version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Prometheus Adapter to IRONdb.
 
+Requiress IRONdb `>= v0.12.0`.
+
+Also check out our launch [blog post](https://www.circonus.com/2018/06/prometheus-adapter/)!
+
 ## Build
 
 Included is a Makefile which will perform all the build tasks you will need


### PR DESCRIPTION
If an on-premises IRONdb customer were to try the adapter without reading the [launch blog post](https://www.circonus.com/2018/06/prometheus-adapter/), neither the adapter or IRONdb would warn him that something's wrong and the metrics would be silently not committed.

This change suggests announcing the IRONdb version requirements and linking to the blog post for more context.