### PR TITLE
panic instead of log.Fatalf

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -49,7 +49,7 @@ func main() {
 	// startup our gosnowth client
 	snowthClient, err := gosnowth.NewSnowthClient(false, snowths...)
 	if err != nil {
-		log.Fatalf("failed to start snowth client: %s", err.Error())
+		panic(fmt.Sprintf("failed to start snowth client: %s", err.Error()))
 	}
 
 	e := echo.New()


### PR DESCRIPTION
log.Fatalf should os.Exit(1), but it is failing to exit.
labstack/gommon/log implements this correctly, but exit is still failing
for some reason. Panic until we can find the source of this interesting
bug.