### PR TITLE
Handle nil value for q.Hints

### DIFF
--- a/handlers/prometheus2_0.go
+++ b/handlers/prometheus2_0.go
@@ -265,7 +265,7 @@ func PrometheusRead2_0(ctx echo.Context) error {
 		var tsChan = make(chan *prompb.TimeSeries, 100)
 
 		var step = 60 * time.Second
-		if q.Hints.StepMs > 0 {
+		if q.Hints != nil && q.Hints.StepMs > 0 {
 			step = time.Duration(q.Hints.StepMs) * time.Millisecond
 		}
 


### PR DESCRIPTION
Fix case where q.Hints is nil. Discovered during testing. Read requests to the adapter trigger this stack trace.
```
echo: http: panic serving 172.20.0.1:46582: runtime error: invalid memory address or nil pointer dereference
goroutine 90465 [running]:
net/http.(*conn).serve.func1(0xc4202be140)
    /home/vagrant/.gvm/gos/go1.10/src/net/http/server.go:1726 +0xd0
panic(0x93e3a0, 0xd4f0e0)
    /home/vagrant/.gvm/gos/go1.10/src/runtime/panic.go:505 +0x229
github.com/circonus-labs/irondb-prometheus-adapter/handlers.PrometheusRead2_0(0xa61240, 0xc42052c000, 0xc420200930, 0xc42041c000)
    /home/vagrant/golang/src/github.com/circonus-labs/irondb-prometheus-adapter/handlers/prometheus2_0.go:268 +0x1710
github.com/circonus-labs/irondb-prometheus-adapter/vendor/github.com/labstack/echo.(*Echo).Add.func1(0xa61240, 0xc42052c000, 0x4, 0xc42041c005)
    /home/vagrant/golang/src/github.com/circonus-labs/irondb-prometheus-adapter/vendor/github.com/labstack/echo/echo.go:482 +0x87
github.com/circonus-labs/irondb-prometheus-adapter/vendor/github.com/labstack/echo.(*Echo).ServeHTTP.func1(0xa61240, 0xc42052c000, 0x9, 0x90a460)
    /home/vagrant/golang/src/github.com/circonus-labs/irondb-prometheus-adapter/vendor/github.com/labstack/echo/echo.go:586 +0x109
main.main.func1.1(0xa61240, 0xc42052c000, 0xc42052c000, 0xa154c0)
    /home/vagrant/golang/src/github.com/circonus-labs/irondb-prometheus-adapter/cmd/server/main.go:68 +0x1e8
github.com/circonus-labs/irondb-prometheus-adapter/vendor/github.com/labstack/echo.(*Echo).ServeHTTP(0xc42022a4e0, 0xa5c0e0, 0xc420308000, 0xc4201fc000)
    /home/vagrant/golang/src/github.com/circonus-labs/irondb-prometheus-adapter/vendor/github.com/labstack/echo/echo.go:594 +0x250
net/http.serverHandler.ServeHTTP(0xc4202285b0, 0xa5c0e0, 0xc420308000, 0xc4201fc000)
    /home/vagrant/.gvm/gos/go1.10/src/net/http/server.go:2694 +0xbc
net/http.(*conn).serve(0xc4202be140, 0xa5c6a0, 0xc420286100)
    /home/vagrant/.gvm/gos/go1.10/src/net/http/server.go:1830 +0x651
created by net/http.(*Server).Serve
    /home/vagrant/.gvm/gos/go1.10/src/net/http/server.go:2795 +0x27b
```