### PR TITLE
Handle race condition, adapter starts w/o snowth

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,7 +11,7 @@
   branch = "master"
   name = "github.com/circonus-labs/gosnowth"
   packages = ["."]
-  revision = "d9323a21598f1137d92f304dd565f2f4f835224e"
+  revision = "9e6f6affc1333a4f1ee771d514f7973bb278eeee"
 
 [[projects]]
   name = "github.com/gogo/protobuf"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with the below command:
 
 ```bash
 docker pull irondb/irondb-prometheus-adapter
-docker run -p1234:8080 docker.io/irondb/irondb-prometheus-adapter:latest /irondb-prometheus-adapter -addr :1234 -log debug -snowth http:127.0.0.1:8112
+docker run -p1234:8080 docker.io/irondb/irondb-prometheus-adapter:latest /irondb-prometheus-adapter -addr :1234 -log debug -snowth http://127.0.0.1:8112
 ```
 
 ## Build

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     depends_on:
       - irondb
     environment:
-      - "GF_SECURITY_ADMIN_PASSWORD=irondb"
+      - "GF_SECURITY_ADMIN_PASSWORD=admin"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/"]
       interval: 1m30s

--- a/vendor/github.com/circonus-labs/gosnowth/README.md
+++ b/vendor/github.com/circonus-labs/gosnowth/README.md
@@ -6,7 +6,7 @@ directly through an exposed HTTP API documented in the IRONdb API documentation:
 
 https://github.com/circonus/irondb-docs/blob/master/api.md
 
-Each of the documented APIs are being implemented at methods of the SnowthClient
+Each of the documented APIs are being implemented as methods of the SnowthClient
 structure defined in this repository.  In order to see the documentation of each
 of the methods, you can use the `godoc` tool to autogenerate the documentation
 shown below:

--- a/vendor/github.com/circonus-labs/gosnowth/client.go
+++ b/vendor/github.com/circonus-labs/gosnowth/client.go
@@ -128,6 +128,7 @@ func NewSnowthClient(discover bool, addrs ...string) (*SnowthClient, error) {
 	// of that node, and populate the identifier and topology of that
 	// node.  Finally we will add the node and activate it.
 	sc.Logger.Info("initializing snowth client")
+	numActiveNodes := 0
 	for _, addr := range addrs {
 		url, err := url.Parse(addr)
 		if err != nil {
@@ -150,7 +151,13 @@ func NewSnowthClient(discover bool, addrs ...string) (*SnowthClient, error) {
 		sc.AddNodes(node)
 		sc.ActivateNodes(node)
 		sc.Logger.Debugf("activated node: %s -> %s", addr, state.Identity)
+		numActiveNodes++
 	}
+
+	if numActiveNodes == 0 {
+		return nil, errors.New("No snowth nodes could be activated")
+	}
+
 	// start a goroutine to watch for changes in state of the nodes,
 	// and manage the active/inactive lists accordingly
 	go sc.watchAndUpdate()

--- a/vendor/github.com/circonus-labs/gosnowth/rollup.go
+++ b/vendor/github.com/circonus-labs/gosnowth/rollup.go
@@ -43,9 +43,9 @@ func (sc *SnowthClient) ReadRollupValues(
 	var (
 		r   = []RollupValues{}
 		err = sc.do(node, "GET", fmt.Sprintf(
-			"%s?start_ts=%d&end_ts=%d&rollup_span=%dms",
+			"%s?start_ts=%d&end_ts=%d&rollup_span=%ds",
 			path.Join("/rollup", id, url.QueryEscape(metricBuilder.String())), start_ts, end_ts,
-			int(rollup/time.Millisecond)), nil, &r, decodeJSONFromResponse)
+			int(rollup/time.Second)), nil, &r, decodeJSONFromResponse)
 	)
 	return r, err
 }


### PR DESCRIPTION
Use updated gosnowth dependency which returns an error on snowth
connection failure. Block on startup snowth client creation until at
least one snowth node is available.

This avoids the existing race condition where the adapter starts without
a snowth connection in an unusable state, most seen using docker-compose
with irondb and grafana.

This problem could have also been solved by adding a service dependency
in docker-compose, but the applied solution aligns more consistenly with
existing user expectations.