### PR TITLE
Change default log level from ALL to ERROR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
 ADD irondb-prometheus-adapter /irondb-prometheus-adapter
-CMD ["/irondb-prometheus-adapter", "-log", "debug", "-addr", ":8080"]
+CMD ["/irondb-prometheus-adapter", "-addr", ":8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM scratch
 ADD irondb-prometheus-adapter /irondb-prometheus-adapter
-CMD ["/irondb-prometheus-adapter", "-addr", ":8080"]
+ENTRYPOINT ["/irondb-prometheus-adapter"]
+CMD ["-addr", ":8080"]

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// the application log level command line flag `-log`
-	appLogLevel logLevel
+	appLogLevel = logLevel(log.ERROR)
 	// the application listen address command line flag `-addr`
 	addr string
 	// the snowth address command line flags `-snowth`

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "8080:8080"
     depends_on:
       - irondb
-    command: /irondb-prometheus-adapter -snowth http://irondb:8112
+    command: -snowth http://irondb:8112
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health-check"]
       interval: 1m30s


### PR DESCRIPTION
### This PR:
- Changes the default log level from 0, which is equivalent to ALL to 4, which is error only.  The default log level, which was being used when run in docker containers, was causing a very large amount of log output to be generated.